### PR TITLE
1.99.0: switch from rspace-os-parent to rspace-parent as parent pom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.99.0]
+- switch from rspace-os-parent to rspace-parent as parent pom
+
 ## [1.98.1]
 
 ### Added

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -4,5 +4,5 @@ before_install:
   - sdk install java 17.0.2-open
   - sdk use java 17.0.2-open
   - java -version
-  - sdk install maven
+  - sdk install maven 3.9.11
   - mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>rspace-client-java-model</artifactId>
-	<version>1.98.1</version>
+	<version>1.99.0</version>
 	<name>rspace-client-java-model</name>
 	<parent>
 		<groupId>com.github.rspace-os</groupId>
-		<artifactId>rspace-os-parent</artifactId>
-		<version>0.1.1</version>
+		<artifactId>rspace-parent</artifactId>
+		<version>2.1.4</version>
 	</parent>
 
 	<repositories>
@@ -31,20 +31,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-log4j12</artifactId>
 			<version>${slf4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -63,17 +51,6 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>${lombok.version}</version>
-			<scope>provided</scope>
-		</dependency>
 	</dependencies>
-
-	<properties>
-		<lombok.version>1.18.42</lombok.version>
-	</properties>
 
 </project>

--- a/src/main/java/com/researchspace/api/clientmodel/FormPost.java
+++ b/src/main/java/com/researchspace/api/clientmodel/FormPost.java
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;


### PR DESCRIPTION
The PR is to complete work on [RSDEV-969](https://researchspace.atlassian.net/browse/RSDEV-969), and stop using rspace-os-parent for rspace dependencies.